### PR TITLE
This should fix a bug for LOG_MAIL that made it use LOG_SYSLOG instead.

### DIFF
--- a/node-syslog.js
+++ b/node-syslog.js
@@ -11,14 +11,14 @@ init: SyslogWrapper.init,
 log: SyslogWrapper.log,
 setMask: SyslogWrapper.setMask,
 close: SyslogWrapper.close,
-version: '1.0.1',
+version: '1.0.2',
 
 /*
  * facilities
  */
 LOG_KERN		: (0<<3),
 LOG_USER		: (1<<3),
-LOG_MAIL		: (5<<3),
+LOG_MAIL		: (2<<3),
 LOG_DAEMON		: (3<<3),
 LOG_AUTH		: (4<<3),
 LOG_SYSLOG		: (5<<3),


### PR DESCRIPTION
I just finished a log.syslog plugin for Haraka that uses node-syslog, and it would not log mail to the correct facility.  Turns out, node-syslog was using the bits for LOG_SYSLOG for the LOG_MAIL facility.  I tested this change on our servers, and node-syslog with LOG_MAIL does the right thing now.

If you can get this change into NPM quickly I would be very greatful.  The Haraka log.syslog plugin won't do the right thing until this is fixed in NPM.  I bumped the version for you.

If you want to talk, you can mail me chris@dod.net, or call me in the US: 207-450-2332.

Cheers,
Chris
