### PR TITLE
Allow usage of node v0.4 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "main": "./node-syslog",
     "engines": {
-        "node" : ">=0.5.7"
+        "node" : ">=0.4.0"
     },
     "description": "Node module to support sending messages to syslog daemon",
     "author": "Nazar Kulyk <nasar.kulyk@googlemail.com>",


### PR DESCRIPTION
When you ported node-syslog to node v0.5.7, you set node >= v.0.5.7 as a requirement in package.json https://github.com/schamane/node-syslog/commit/d3c2014a52795a77b4969dd374df753b47aaa8e1#L3R9

After you made it working again under 0.4, you forgot to mark that in package.json https://github.com/schamane/node-syslog/commit/bcf98461022001f31361927875ba3528dd6a6461
