### PR TITLE
Build an empty addon on win32

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,13 @@
     "targets": [
 	{
 	    "target_name": "syslog",
-	    "sources": [ "syslog.cc" ],
+            "conditions": [
+                ['OS=="win"', {
+                    "sources": ["syslog-win.cc"],
+                }, {
+                    "sources": ["syslog.cc"],
+                }]
+            ],
 	    "cflags": [
 		"-fPIC"
 	    ]

--- a/node-syslog.js
+++ b/node-syslog.js
@@ -59,6 +59,8 @@ LOG_DEBUG		: 7
  *
  * XXX(sam) consider using AtExit: joyent/node#e4a8d261
  */
-process.on('exit', function() {
-	SyslogWrapper.close();
-});
+if (SyslogWrapper.close) {
+	process.on('exit', function() {
+		SyslogWrapper.close();
+	});
+}

--- a/syslog-win.cc
+++ b/syslog-win.cc
@@ -1,0 +1,10 @@
+// Stub module on Windows, so dependency builds, and syslog can be detected at
+// run-time as unsupported
+
+#include <node.h>
+
+static void Initialize ( v8::Handle<v8::Object> target)
+{
+}
+
+NODE_MODULE(syslog, Initialize);

--- a/test.js
+++ b/test.js
@@ -1,6 +1,12 @@
 var assert = require('assert');
 var Syslog = require('./node-syslog');
 
+if (process.platform == "win32") {
+  assert(Syslog.init === undefined);
+  console.log('PASS');
+  return;
+}
+
 assert.throws(function() {
   Syslog.init();
 }, Error);


### PR DESCRIPTION
Npm does not support platform sensitive dependencies, and will always
attempt to build syslog even if its not going to be used. The error
messages are disturbing to naive users. Instead, compile syslog into a
an empty addon, so that it builds sucessfully, but won't have an .init()
method. This supports run-time detection of syslog capability, rather
than npm install time build failures.
