### PR TITLE
compat.h: Remove ReturnableHandleScope::Return(intptr_t)

### DIFF
--- a/compat-inl.h
+++ b/compat-inl.h
@@ -120,10 +120,6 @@ ReturnType ReturnableHandleScope::Return(bool value) {
   return Return(Boolean::New(isolate(), value));
 }
 
-ReturnType ReturnableHandleScope::Return(intptr_t value) {
-  return Return(Integer::New(isolate(), value));
-}
-
 ReturnType ReturnableHandleScope::Return(int value) {
   return Return(Integer::New(isolate(), value));
 }

--- a/compat.h
+++ b/compat.h
@@ -127,7 +127,6 @@ class ReturnableHandleScope {
   inline explicit ReturnableHandleScope(const ArgumentType& args);
   inline ReturnType Return();
   inline ReturnType Return(bool value);
-  inline ReturnType Return(intptr_t value);
   inline ReturnType Return(int value);
   inline ReturnType Return(double value);
   inline ReturnType Return(const char* value);


### PR DESCRIPTION
The Return() method of the ReturnableHandleScope class is overloaded
with `intptr_t` and `int`. On 32-bit FreeBSD 8.1, an `intptr_t` is an
`int`:

    /usr/include/machine/_types.h:typedef    int            __int32_t;
    /usr/include/machine/_types.h:typedef    __int32_t    __intptr_t;
    /usr/include/sys/stdint.h:typedef    __intptr_t        intptr_t;

Since the method signatures are equivalent, it causes a compile error:

      CXX(target) Release/obj.target/syslog/syslog.o
    In file included from ../node-syslog.h:13,
                     from ../syslog.cc:1:
    ../compat.h:127: error: 'compat::ReturnType compat::ReturnableHandleScope::Return(int)' cannot be overloaded
    ../compat.h:126: error: with 'compat::ReturnType compat::ReturnableHandleScope::Return(intptr_t)'
    In file included from ../syslog.cc:2:
    ../compat-inl.h:127: error: redefinition of 'compat::ReturnType compat::ReturnableHandleScope::Return(int)'
    ../compat-inl.h:123: error: 'compat::ReturnType compat::ReturnableHandleScope::Return(intptr_t)' previously defined here

This patch removes the ReturnableHandleScope::Return(intptr_t) method
as it isn't used.

Tested on 64-bit Mac OS X 10.10.3 with node 0.10.32 and 32-bit FreeBSD 8.1
with node 0.10.28.